### PR TITLE
fix getSelection when selection is  end-of-line <br/>

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -132,6 +132,10 @@ export function getRange(el) {
       break;
     }
 
+    if (isBr(next) && endContainer === next) {
+      break;
+    }
+
     if (!isClosing) {
       if (
         isBr(next) || (

--- a/test/test.js
+++ b/test/test.js
@@ -263,6 +263,23 @@ describe('selection-ranges', function() {
       });
     });
 
+    it('at end-of-line <br /> (Firefox style)', function() {
+
+      // given
+      node.innerHTML = 'FOO<br>BAR';
+
+      const range = document.createRange();
+      range.setStart(node.childNodes[1], 0);
+      range.setEnd(node.childNodes[1], 0);
+
+      applyRange(range);
+
+      expect(getRange(node)).to.eql({
+        start: 3,
+        end: 3
+      });
+    });
+
 
     describe('caret', function() {
 


### PR DESCRIPTION
### Which issue does this PR address?

Hey there, me again. I've spent the day working on adding newline support to our contenteditable implementation, and found another niche edge with this util. 

Reproduction:

1. Consider the innerHtml
```
FOO<br/><br/>bar
```
which displays as 
```
FOO

bar
```

2. Place your cursor on the empty line between "FOO" and "bar"
3. Press "Backspace"

At this point, the inner HTML should be `FOO<br/>bar`, and you expect the cursor to be at the tail end of the first row.  This means a call to `getRange()` should result in `{start:3, end: 3}`.

In Safari & Chrome, this works as expected. However, in Firefox, the current implementation falls through, so the cursor is at the end of the content (`{start: 7, end: 7}`). After dissecting further, I discovered this is because Firefox sets the `startContainer`/`endContainer` nodes to be the trailing `<br/>` itself, whereas Chrome & Safari put at it `offset: 4` on the `#text` node.

My proposed fix here is to eject from the node traversal if we detect the current iterator equals the end container (only if the end container itself is a `<br/>`). I considered modifying the `isBeforeEnd` util, but I'm not confident enough in my understanding of its current implementation to warrant it. In any case, I think sharp-shooting this edge seems fine.

I've added a test which passes, and showcases the failure with the fix removed.